### PR TITLE
Increase maximum rounds from 20 to 60

### DIFF
--- a/WorkoutTimer/VIews/RoundsPickerView.swift
+++ b/WorkoutTimer/VIews/RoundsPickerView.swift
@@ -30,9 +30,9 @@ struct RoundsPickerView: View {
                     .fontWeight(.bold)
                     .frame(minWidth: 80)
                 
-                // Increment button - increases rounds (maximum 20).
+                // Increment button - increases rounds (maximum 60).
                 Button(action: {
-                    if rounds < 20 { rounds += 1 }
+                    if rounds < 60 { rounds += 1 }
                 }) {
                     Image(systemName: "plus.circle.fill")
                         .font(.largeTitle)


### PR DESCRIPTION
## Summary
- Increases the maximum number of workout rounds from 20 to 60 in RoundsPickerView
- Updates increment button logic and comment to reflect new limit
- Enables support for longer workout sessions

## Changes Made
- Modified `RoundsPickerView.swift:35` from `if rounds < 20` to `if rounds < 60`
- Updated comment to reflect new maximum of 60 rounds

## Test Plan
- [ ] Verify rounds picker allows incrementing up to 60
- [ ] Verify rounds picker still prevents going below 1 
- [ ] Test that UI displays correctly with larger round numbers
- [ ] Confirm workout functionality works with higher round counts

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)