### PR TITLE
Fix timer freezing when iPhone screen goes to sleep

### DIFF
--- a/WorkoutTimer/Models/WorkoutModel.swift
+++ b/WorkoutTimer/Models/WorkoutModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import UIKit
 
 class WorkoutModel: ObservableObject {
     @Published var rounds: Int = 3
@@ -27,6 +28,9 @@ class WorkoutModel: ObservableObject {
             isWorking = false
             timeRemaining = prepTime
             
+            // Prevent screen from sleeping during workout
+            UIApplication.shared.isIdleTimerDisabled = true
+            
             SoundManager.shared.playSound(for: .prepStart)
             startTimer()
         }
@@ -48,6 +52,9 @@ class WorkoutModel: ObservableObject {
         timeRemaining = 0
         isWorking = true
         isPreparing = false
+        
+        // Re-enable screen sleep when workout ends
+        UIApplication.shared.isIdleTimerDisabled = false
     }
     
     private func startTimer() {
@@ -90,6 +97,8 @@ class WorkoutModel: ObservableObject {
                             // Workout complete - no final rest period
                             SoundManager.shared.playSound(for: .workoutComplete)
                             HapticManager.shared.notification(type: .success)
+                            // Re-enable screen sleep when workout completes
+                            UIApplication.shared.isIdleTimerDisabled = false
                             self.resetWorkout()
                         } else {
                             // Switch to rest

--- a/WorkoutTimer/VIews/ContentView.swift
+++ b/WorkoutTimer/VIews/ContentView.swift
@@ -15,6 +15,10 @@ struct ContentView: View {
     @State private var showingSettings = false
     /// App storage for dark mode preference that persists across app launches.
     @AppStorage("isDarkMode") private var isDarkMode = false
+    /// Controls the display of the battery warning alert.
+    @State private var showingBatteryWarning = false
+    /// App storage to track if battery warning has been shown before.
+    @AppStorage("hasShownBatteryWarning") private var hasShownBatteryWarning = false
     
     var body: some View {
         NavigationStack {
@@ -35,7 +39,11 @@ struct ContentView: View {
                         Spacer()
                         // Start workout button.
                         Button(action: {
-                            workoutModel.startWorkout()
+                            if !hasShownBatteryWarning {
+                                showingBatteryWarning = true
+                            } else {
+                                workoutModel.startWorkout()
+                            }
                         }) {
                             Text("START")
                                 .font(.title)
@@ -90,6 +98,15 @@ struct ContentView: View {
                 .presentationDragIndicator(.visible)
         }
         .preferredColorScheme(isDarkMode ? .dark : .light)
+        .alert("Screen Will Stay On", isPresented: $showingBatteryWarning) {
+            Button("Got It") {
+                hasShownBatteryWarning = true
+                workoutModel.startWorkout()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("During workouts, the screen will stay on to prevent the timer from stopping. This may use more battery than usual.")
+        }
     }
     
     /// Converts total workout time from seconds to a formatted string (MM:SS).


### PR DESCRIPTION
## Summary
- Prevents screen from going to sleep during workouts using `UIApplication.isIdleTimerDisabled`
- Shows one-time battery warning alert to inform users about increased battery usage
- Re-enables screen sleep when workout ends, resets, or completes
- Resolves Issue #2: Timer continues running even when screen would normally sleep

## Changes Made
- **WorkoutModel.swift**: Added UIKit import and screen wake prevention logic
- **ContentView.swift**: Added battery warning alert with user consent

## Test Plan
- [x] Start a workout and verify screen doesn't sleep during timer countdown
- [x] Complete a workout and verify screen sleep behavior returns to normal  
- [x] Reset a workout mid-session and verify screen sleep is re-enabled
- [x] Verify battery warning alert shows on first workout start
- [x] Verify battery warning alert doesn't show on subsequent workout starts

🤖 Generated with [Claude Code](https://claude.ai/code)